### PR TITLE
Remove hard dependency to bootstrap in bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,9 +19,7 @@
     "bower_components"
   ],
   "devDependencies": {
-    "angular": "~1.4.8"
-  },
-  "dependencies": {
+    "angular": "~1.4.8",
     "bootstrap": "~3.3.6"
   }
 }


### PR DESCRIPTION
I’d like to remove this dependency in the bower file because:
- The only actual requirement is to get Bootstrap’s CSS not the javascript part of it.
- I’m using [bootstrap-sass](https://github.com/twbs/bootstrap-sass) in my project, therefore I satisfy the above, yet bower is fetching bootstrap.
- That’s the approach of [AngularUI bootstrap](https://github.com/angular-ui/bootstrap-bower/blob/master/bower.json)
