### PR TITLE
Add export module to use with es6 syntax import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./src/aside-menu.js');
+module.exports = 'asideModule';


### PR DESCRIPTION
With this feature we can use import syntax.

Example: import asideModule from 'angular-aside-menu'